### PR TITLE
Handle Ruby 2.7 deprecation

### DIFF
--- a/lib/get_schwifty/cable/base.rb
+++ b/lib/get_schwifty/cable/base.rb
@@ -17,16 +17,20 @@ module GetSchwifty
       def stream(*args)
         ActionCable.server.broadcast(
           schwifty_job_id,
-          status: 200,
-          body: GetSchwiftyController.renderer.new.render(*args).squish
+          { 
+            status: 200,
+            body: GetSchwiftyController.renderer.new.render(*args).squish
+          }
         )
       end
 
       def redirect(url)
         ActionCable.server.broadcast(
           schwifty_job_id,
-          status: 302,
-          body: url
+          {
+            status: 302,
+            body: url
+          }
         )
       end
     end


### PR DESCRIPTION
This is the warning: Passing the keyword argument as the last hash parameter is deprecated.

This is needed so the Bento app can be upgraded to Ruby 3.0 successfully.